### PR TITLE
Enable support for Laravel 11 which uses illuminate/http 11.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "illuminate/http": "^7.0|^8.0|^9.0|^10.0"
+        "illuminate/http": "^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add support for Laravel 11 which uses illuminate/http 11.x.

Reference -- issue #2 