### PR TITLE
Make test_event_code optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ $eventB->setEventName(\Msaaq\TikTok\Enums\EventName::PLACE_AN_ORDER)
 
 ```php
 $eventRequest = $tiktok->events()
-            ->setEventSource(\Msaaq\TikTok\Enums\EventSource::WEB)
-            ->setTestEventCode($testCode); // optional 
+            ->setEventSource(\Msaaq\TikTok\Enums\EventSource::WEB);
+if (!empty($testCode)) {
+       $eventRequest->setTestEventCode($testCode); // optional 
+}
 ```
 
 ### Sending a single event

--- a/src/Requests/EventRequest.php
+++ b/src/Requests/EventRequest.php
@@ -55,13 +55,18 @@ class EventRequest
             $events[$key] = $event->toArray();
         }
 
-        $request = $this->http->post('/event/track/', [
+        $requestData = [
             'event_source' => $this->event_source->value,
             'event_source_id' => $this->event_source_id,
-            'test_event_code' => $this->test_event_code,
 
             'data' => $events,
-        ]);
+        ];
+
+        if (!empty($this->test_event_code)) {
+            $requestData['test_event_code'] = $this->test_event_code;
+        }
+
+        $request = $this->http->post('/event/track/', $requestData);
 
         $request->onError(function ($request) {
             $errorCode = $request->json('code');


### PR DESCRIPTION
Make test_event_code optional by conditionally adding it to the request data only if set.

@see https://github.com/msaaqcom/tiktok-php-sdk/issues/1