### PR TITLE
Add support for Laravel 12.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "illuminate/http": "^7.0|^8.0|^9.0|^10.0|^11.0"
+        "illuminate/http": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add support for Laravel 12 which uses illuminate/http 12.x.

@see https://github.com/msaaqcom/tiktok-php-sdk/issues/7