### PR TITLE
Add StartTrial and Purchase constants to TikTok event enum

### DIFF
--- a/src/Enums/EventName.php
+++ b/src/Enums/EventName.php
@@ -18,4 +18,6 @@ enum EventName: string
     case SUBMIT_FORM = 'SubmitForm';
     case COMPLETE_REGISTRATION = 'CompleteRegistration';
     case SUBSCRIBE = 'Subscribe';
+    case START_TRIAL = 'StartTrial';
+    case PURCHASE = 'Purchase';
 }


### PR DESCRIPTION
Add StartTrial and Purchase constants to TikTok event enum which were missing

TikTok Documentation with these events listed: https://ads.tiktok.com/help/article/supported-standard-events